### PR TITLE
Parse HUBOT_GITHUB_API, setting host, prefix and protocol.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "MIT",
   "main": "./src/hubot-github-adapter",
   "dependencies": {
+    "github": "^0.2.4",
     "hubot-github-webhook-listener": "^0.9.0"
   },
   "devDependencies": {

--- a/src/hubot-github-adapter.coffee
+++ b/src/hubot-github-adapter.coffee
@@ -6,6 +6,7 @@
 GitHubApi = require("github");
 
 GithubMessage = require("./github-message");
+Url = require("url")
 
 class Github extends Adapter
   constructor: (robot) ->
@@ -17,7 +18,7 @@ class Github extends Adapter
 
     return console.error "No Github token provided to Hubot" unless @options.token
 
-    @githubClient = new GitHubApi(version: "3.0.0")
+    @githubClient = new GitHubApi(@options)
     @githubClient.authenticate
       type: "oauth",
       token: @options.token
@@ -93,8 +94,15 @@ class Github extends Adapter
     @send envelope, strings...
 
   parseOptions: ->
-    @options =
-      token : process.env.HUBOT_GITHUB_TOKEN
+    @options = {
+      token: process.env.HUBOT_GITHUB_TOKEN,
+      version: "3.0.0"
+    }
+    if process.env.HUBOT_GITHUB_API
+      parsedUrl = Url.parse(process.env.HUBOT_GITHUB_API)
+      @options.host = parsedUrl.host
+      @options.pathPrefix = parsedUrl.path
+      @options.protocol = parsedUrl.protocol.replace /:$/, ''
 
   createGithubComment: (user, repo, issueNumber, commentBody) =>
     @githubClient.issues.createComment {


### PR DESCRIPTION
This PR adds the ability to set the `host`, `prefix` and `protocol` client options via the ENV variable `HUBOT_GITHUB_API`. This conforms to the Hubot ecosystem Github client configuration API (e.g. [hubot-deploy](https://github.com/atmos/hubot-deploy), [github-merge](https://github.com/github/hubot-scripts/blob/master/src/scripts/github-merge.coffee), etc.).
